### PR TITLE
[1.0.2] Report using display_names and create players that dont exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [1.0.2] - 2020-09-19
 ### Changed
-- Update all reports to display `display_name`s instead of discord member name.
+- Updated all reports to display `display_name`s instead of discord member name.
+- Updated `.myelo` to create a player record with default elo if player does not exist.
 
 ### [1.0.1] - 2020-09-18
 ### Changed
 - Updated matches to only be recorded and monitored for game modes that are configured in `config.MONITORED_GAME_MODES`.
-- Update `.myelo` command to report a more helpful message when a player doesn't exist in the database.
+- Updated `.myelo` command to report a more helpful message when a player doesn't exist in the database.
 
 ### [1.0.0] - 2020-09-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please log all key deployments here. They include all major changes and customiz
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.0.2] - 2020-09-19
+### Changed
+- Update all reports to display `display_name`s instead of discord member name.
+
 ### [1.0.1] - 2020-09-18
 ### Changed
 - Updated matches to only be recorded and monitored for game modes that are configured in `config.MONITORED_GAME_MODES`.

--- a/rankone/bot.py
+++ b/rankone/bot.py
@@ -13,6 +13,7 @@ from . import reporter
 from . import db
 from . import config
 from . import parser
+from . import utils
 
 
 logger = get_logger(logging.INFO)
@@ -113,6 +114,11 @@ async def on_reaction_add(reaction, user):
                 )
                 db.update_player_elo(teams[winning_team].players, win_elo)
                 db.update_player_elo(teams[losing_team].players, lose_elo)
+
+                for player in players:
+                    player.display_name = utils.get_display_name(
+                        reaction.message.guild.members, player.player_id
+                    )
 
                 elo_report_message = reporter.get_elo_report(*players, has_updated=True)
                 match_updated_message = reporter.as_bot(

--- a/rankone/commands.py
+++ b/rankone/commands.py
@@ -36,12 +36,13 @@ class Commands(commands.Cog):
 
     @commands.command(name='myelo')
     async def myelo(self, ctx):
-        player_id = ctx.author.id
+        player_id, name = ctx.author.id, ctx.author.name
         player = db.get_player(player_id)
         if player:
             report = reporter.get_elo_report(player)
         else:
-            report = reporter.as_bot('Player does not exist')
+            player = db.add_player(player_id, name)
+            report = reporter.get_elo_report(player)
         await ctx.send(report)
 
     @commands.command(name='elo')

--- a/rankone/commands.py
+++ b/rankone/commands.py
@@ -39,9 +39,15 @@ class Commands(commands.Cog):
         player_id, name = ctx.author.id, ctx.author.name
         player = db.get_player(player_id)
         if player:
+            player.display_name = utils.get_display_name(
+                ctx.guild.members, player_id=int(player_id)
+            )
             report = reporter.get_elo_report(player)
         else:
             player = db.add_player(player_id, name)
+            player.display_name = utils.get_display_name(
+                ctx.guild.members, player_id=int(player_id)
+            )
             report = reporter.get_elo_report(player)
         await ctx.send(report)
 
@@ -52,6 +58,10 @@ class Commands(commands.Cog):
             players = list(
                 filter(None, [db.get_player(player_id) for player_id in player_ids])
             )
+            for player in players:
+                player.display_name = utils.get_display_name(
+                    ctx.guild.members, player_id=int(player.id)
+                )
             if players:
                 report = reporter.get_elo_report(*players)
             else:
@@ -87,4 +97,8 @@ class Commands(commands.Cog):
     async def elo_leaders(self, ctx):
         top_limit = 10
         leaders = db.get_top_n_players(top_limit)
+        for player in leaders:
+            player.display_name = utils.get_display_name(
+                ctx.guild.members, player_id=int(player.id)
+            )
         await ctx.send(reporter.get_leader_report(leaders))

--- a/rankone/db.py
+++ b/rankone/db.py
@@ -119,6 +119,13 @@ def get_player(player_id):
     return player
 
 
+def add_player(player_id, name):
+    player = Player(id=player_id, name=name, updated_at=datetime.now())
+    session.add(player)
+    session.commit()
+    return player
+
+
 def show_db():
     results = [result.__dict__ for result in session.query(Match).all()]
     df = pd.DataFrame(results)

--- a/rankone/reporter.py
+++ b/rankone/reporter.py
@@ -17,7 +17,7 @@ def bot_message(func):
 @bot_message
 def get_report(players):
     report = ', '.join(
-        [f'{player.name}: {random.randint(900, 1700)}' for player in players]
+        [f'{player.display_name}: {random.randint(900, 1700)}' for player in players]
     )
     return report
 
@@ -25,7 +25,9 @@ def get_report(players):
 @bot_message
 def get_elo_report(*players, has_updated=False):
 
-    report = ', '.join(f'{player.name} [{player.elo:4.0f}]' for player in players)
+    report = ', '.join(
+        f'{player.display_name} [{player.elo:4.0f}]' for player in players
+    )
     header = 'Elo updated! '
     if has_updated:
         report = header + report
@@ -37,5 +39,5 @@ def get_leader_report(players):
     # assumes players are already sorted in descending
     report = f'Top {len(players)} players: \n'
     for i, player in enumerate(players):
-        report = report + f'{i+1}. {player.name} [{player.elo:4.0f}]\n'
+        report = report + f'{i+1}. {player.display_name} [{player.elo:4.0f}]\n'
     return report

--- a/rankone/utils.py
+++ b/rankone/utils.py
@@ -2,6 +2,8 @@ from datetime import datetime
 import os
 import subprocess
 
+from discord import utils as discord_utils
+
 from . import db
 
 
@@ -44,3 +46,8 @@ def reset_db():
     result = subprocess.call(cmd) == 0
     db.session = db.get_session()
     return result
+
+
+def get_display_name(members, player_id):
+    member = discord_utils.get(members, id=player_id)
+    return member.display_name

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='rankone',
-    version='1.0.1',
+    version='1.0.2',
     packages=pkgs,
     description='RankOne is a discord bot that manages a Elo ladder for pickup games.',
     long_description=README,


### PR DESCRIPTION
### [1.0.2] - 2020-09-19
### Changed
- Updated all reports to display `display_name`s instead of discord member name.
- Updated `.myelo` to create a player record with default elo if player does not exist.
