### PR TITLE
[1.1.2] Add a MatchManager to handle match added and match updated events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Please log all key deployments here. They include all major changes and customiz
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.1.2] - 2020-09-22
+### Added
+- Added a MatchManager to handle match added and match updated events.
+- Added type hints to the codebase and simplified heavy functions into simple ones.
+
 ### [1.1.1] - 2020-09-21
 ### Changed
 - The bot new reacts to any recognized match message with an emoji :crossed_swords: to help players identify them visually.

--- a/rankone/algorithms.py
+++ b/rankone/algorithms.py
@@ -1,10 +1,14 @@
+from typing import Tuple
+from .player import Team
 from trueskill import TrueSkill
 
 
 trueskill = TrueSkill()
 
 
-def configure_trueskill(mu=None, sigma=None, beta=None, tau=None):
+def configure_trueskill(
+    mu: float = None, sigma: float = None, beta: float = None, tau: float = None
+):
     '''
     Configure `TrueSkill` with different settings.
     '''
@@ -14,7 +18,7 @@ def configure_trueskill(mu=None, sigma=None, beta=None, tau=None):
     trueskill.tau = tau or trueskill.tau
 
 
-def threshold_elo_gains(team1, team2):
+def threshold_elo_gains(team1: Team, team2: Team) -> Tuple(int, int):
     '''
     Returns 40, -40 elo gains IF the respective teams
     have less than 100 total combined games. Otherwise
@@ -32,11 +36,11 @@ def threshold_elo_gains(team1, team2):
     return team1_elo, team2_elo
 
 
-def basic_elo_gains(team1, team2):
+def basic_elo_gains(team1: Team, team2: Team) -> Tuple(int, int):
     return 15, -15
 
 
-def elo_gains_v1(team1, team2):
+def elo_gains_v1(team1: Team, team2: Team) -> Tuple(int, int):
     '''
     Calculates using an ELO formula but does not take into account
     the number of games.
@@ -61,7 +65,7 @@ def elo_gains_v1(team1, team2):
     return team1_shared_win, team2_shared_loss
 
 
-def true_skill_ratings(winning_team, losing_team):
+def true_skill_ratings(winning_team: Team, losing_team: Team) -> Tuple[Team, Team]:
     '''
     Returns winning team and losing team with adjusted ratings, elo, and sigma
     '''

--- a/rankone/algorithms.py
+++ b/rankone/algorithms.py
@@ -18,7 +18,7 @@ def configure_trueskill(
     trueskill.tau = tau or trueskill.tau
 
 
-def threshold_elo_gains(team1: Team, team2: Team) -> Tuple(int, int):
+def threshold_elo_gains(team1: Team, team2: Team) -> Tuple[Team, Team]:
     '''
     Returns 40, -40 elo gains IF the respective teams
     have less than 100 total combined games. Otherwise
@@ -33,14 +33,26 @@ def threshold_elo_gains(team1: Team, team2: Team) -> Tuple(int, int):
     if team2.combined_weight < 100:
         team2_elo = -40
 
-    return team1_elo, team2_elo
+    for player in team1.players:
+        player._elo = player.elo + team1_elo
+
+    for player in team2.players:
+        player._elo = player.elo + team2_elo
+
+    return team1, team2
 
 
-def basic_elo_gains(team1: Team, team2: Team) -> Tuple(int, int):
-    return 15, -15
+def basic_elo_gains(team1: Team, team2: Team) -> Tuple[Team, Team]:
+    for player in team1.players:
+        player._elo = player.elo + 15
+
+    for player in team2.players:
+        player._elo = player.elo - 15
+
+    return team1, team2
 
 
-def elo_gains_v1(team1: Team, team2: Team) -> Tuple(int, int):
+def elo_gains_v1(team1: Team, team2: Team) -> Tuple[Team, Team]:
     '''
     Calculates using an ELO formula but does not take into account
     the number of games.
@@ -62,7 +74,13 @@ def elo_gains_v1(team1: Team, team2: Team) -> Tuple(int, int):
     team1_shared_win = (r1 - team1.combined_elo) / len(team1.players)
     team2_shared_loss = (r2 - team2.combined_elo) / len(team2.players)
 
-    return team1_shared_win, team2_shared_loss
+    for player in team1.players:
+        player._elo = player.elo + team1_shared_win
+
+    for player in team2.players:
+        player._elo = player.elo + team1_shared_loss
+
+    return team1, team2
 
 
 def true_skill_ratings(winning_team: Team, losing_team: Team) -> Tuple[Team, Team]:

--- a/rankone/commands.py
+++ b/rankone/commands.py
@@ -34,6 +34,17 @@ class Commands(commands.Cog):
         response = utils.restore_db(backup_id)
         await ctx.send(reporter.as_bot(response))
 
+    @commands.command(name='reset_db')
+    @commands.has_any_role(config.ADMIN_ROLE)
+    async def reset_db(self, ctx):
+        backup_id = utils.backup_db()
+        response = f'Backup {backup_id} created first before resetting elo\n'
+        if utils.reset_db():
+            response = response + 'DB reset.'
+        else:
+            response = response = 'Unable to reset DB'
+        await ctx.send(reporter.as_bot(response))
+
     @commands.command(name='myelo')
     async def myelo(self, ctx):
         player_id, name = ctx.author.id, ctx.author.name
@@ -68,17 +79,6 @@ class Commands(commands.Cog):
                 report = reporter.as_bot("Players don't exist")
 
             await ctx.send(report)
-
-    @commands.command(name='reset_db')
-    @commands.has_any_role(config.ADMIN_ROLE)
-    async def reset_db(self, ctx):
-        backup_id = utils.backup_db()
-        response = f'Backup {backup_id} created first before resetting elo\n'
-        if utils.reset_db():
-            response = response + 'DB reset.'
-        else:
-            response = response = 'Unable to reset DB'
-        await ctx.send(reporter.as_bot(response))
 
     @commands.command(name='reset_elo')
     @commands.has_any_role(config.ADMIN_ROLE)

--- a/rankone/db.py
+++ b/rankone/db.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import pandas as pd
 import uuid
+from typing import List
 
 from sqlalchemy.engine.url import URL
 from sqlalchemy.schema import Column
@@ -12,6 +13,7 @@ from sqlalchemy import update
 
 
 from . import config
+from .player import Team
 
 
 sqlite_db = {'drivername': 'sqlite', 'database': 'db.sqlite'}
@@ -55,7 +57,9 @@ def get_session():
 session = get_session()
 
 
-def add_match(red, blue, message_id, match_created_at):
+def add_match(
+    red: Team, blue: Team, message_id: int, match_created_at: datetime
+) -> bool:
     '''
     Given a `red` and `blue` team and a `message_id` responsible for
     creating the match, add the match to the DB.
@@ -87,7 +91,7 @@ def add_match(red, blue, message_id, match_created_at):
     return True
 
 
-def set_winner(match_id, winning_team):
+def set_winner(match_id: int, winning_team: str) -> bool:
     '''
     Given a match_id, set all players belonging to `winning_team` as winners.
     '''
@@ -105,23 +109,23 @@ def set_winner(match_id, winning_team):
     return True
 
 
-def get_match(match_id):
+def get_match(match_id: int) -> Match:
     match = session.query(Match).filter(Match.match_id == match_id)
     return match
 
 
-def get_match_winner(match_id):
+def get_match_winner(match_id: int) -> Match:
     match = get_match(match_id)
     winner = match.filter(Match.win == True).distinct().first()
     return winner
 
 
-def get_player(player_id):
+def get_player(player_id: int) -> Player:
     player = session.query(Player).filter(Player.id == player_id).first()
     return player
 
 
-def add_player(player_id, name):
+def add_player(player_id: int, name: str) -> Player:
     player = Player(id=player_id, name=name, updated_at=datetime.now())
     session.add(player)
     session.commit()
@@ -140,7 +144,7 @@ def show_players():
     print(df[['id', 'name', 'elo', 'sigma']])
 
 
-def register_players(players):
+def register_players(players: Player) -> bool:
     '''
     Checks if players exist in Player table. If not, adds them to the Player table.
     '''
@@ -153,7 +157,7 @@ def register_players(players):
     return True
 
 
-def update_player_elo(players):
+def update_player_elo(players: List[Player]) -> bool:
     '''
     Updates the database with the latest player.elo, and player.sigma
     for every player in `players`.
@@ -167,7 +171,7 @@ def update_player_elo(players):
     return True
 
 
-def reset_all_elo():
+def reset_all_elo() -> bool:
     '''
     Reset elo and sigma for ALL players.
     '''
@@ -184,6 +188,6 @@ def reset_all_elo():
     return True
 
 
-def get_top_n_players(n):
+def get_top_n_players(n: int) -> List[Player]:
     top_players = session.query(Player).order_by(Player.elo.desc()).limit(n)
     return top_players.all()

--- a/rankone/elo.py
+++ b/rankone/elo.py
@@ -1,16 +1,22 @@
+from typing import Callable, Tuple
+from .player import Player, Team
 from .algorithms import elo_gains_v1
 
 
 class EloSystem:
-    def __init__(self, algorithm=elo_gains_v1, elo_gain_limit=5):
+    def __init__(
+        self,
+        algorithm: Callable[[Team, Team], Tuple[Team, Team]] = elo_gains_v1,
+        elo_gain_limit: int = 5,
+    ):
         self.elo_cache = {'id': 0}  # only necessary if DB is too slow.
         self.algorithm = algorithm
         self.elo_gain_limit = elo_gain_limit
 
-    def get_elo(self, player_id):
+    def get_elo(self, player_id: int):
         return self.elo_db.get(player_id)
 
-    def set_elo(self, player_id, elo):
+    def set_elo(self, player_id: int, elo: float):
         self.elo_cache[player_id] = elo
 
     def persist_elos(self):
@@ -25,7 +31,9 @@ class EloSystem:
         '''
         raise NotImplementedError
 
-    def calculate_elo_gains(self, winning_team, losing_team):
+    def calculate_elo_gains(
+        self, winning_team: Team, losing_team: Team
+    ) -> Tuple[Team, Team]:
         '''
         Calculates elo gains for winning and losing teams using `EloSystem.algorithm`
         '''

--- a/rankone/match.py
+++ b/rankone/match.py
@@ -1,0 +1,100 @@
+from typing import Awaitable, Any, List, Callable
+from discord import Message, Reaction
+from . import parser
+from . import config
+from . import db
+from . import utils
+from . import reporter
+from .elo import EloSystem
+from .player import Player
+
+
+class MatchManager(object):
+    def __init__(self, elo_system: EloSystem):
+        self.elo_system = elo_system
+
+    def is_match(self, message: Message) -> bool:
+        return (
+            (message.channel.id in config.MONITORED_CHANNELS)
+            and parser.is_monitored_match(message)
+            and parser.is_match(message)
+        )
+
+    def is_match_reaction(self, reaction: Reaction) -> bool:
+        return reaction.emoji in config.MONITORED_REACTIONS
+
+    async def update_match(
+        self, reaction: Reaction, callbacks: List[Callable[[Any], Any]]
+    ):
+        '''
+        Handle a match updated through reaction event by parsing the match
+        message, parsing the match winners, recalculating elo based on results,
+        updating the database with adjusted elo, and reporting back to the channel
+        of the updated elos.
+        '''
+        winning_team = config.MONITORED_REACTIONS.get(reaction.emoji)
+
+        message = reaction.message
+        match_id = message.id
+        match_winner = db.get_match_winner(match_id)
+        losing_team = (
+            set(config.MONITORED_REACTIONS.values()) - set([winning_team])
+        ).pop()
+
+        # only proceed if the match hasn't already been recorded or if
+        # the new match winner is not the existing marked winner
+        if not match_winner or match_winner.team != winning_team:
+            db.set_winner(match_id, winning_team)
+
+            match_id, players, teams = parser.parse_match(message)
+
+            winning_team, losing_team = self.elo_system.calculate_elo_gains(
+                teams[winning_team], teams[losing_team]
+            )
+
+            db.update_player_elo(winning_team.players)
+            db.update_player_elo(losing_team.players)
+
+            updated_players = self.update_player_display_names(
+                players, reaction.message
+            )
+            report = reporter.get_elo_report(*updated_players, has_updated=True)
+
+            for callback in callbacks:
+                await callback(reaction, report)
+
+    def update_player_display_names(self, players: Player, message) -> List[Player]:
+        '''
+        Given a list of players, updates the player's display_name attribute.
+        '''
+        for player in players:
+            player.display_name = utils.get_display_name(
+                message.guild.members, player.player_id
+            )
+        return players
+
+    async def add_match(self, message: Message, callbacks: List[Callable[[Any], Any]]):
+        '''
+        Handle a match added event by parsing the match message, parsing
+        the teams and players, adding the match to the DB, and
+        reporting back to the channel that the match has been added.
+        '''
+        await message.add_reaction(config.MATCH_REACTION)
+
+        match_id, players, teams = parser.parse_match(message)
+        match_created_at = message.created_at
+
+        db.add_match(teams['Red'], teams['Blue'], match_id, match_created_at)
+        db.register_players(teams['Red'].players + teams['Blue'].players)
+
+        red_players = self.update_player_display_names(teams['Red'].players, message)
+        blue_players = self.update_player_display_names(teams['Blue'].players, message)
+
+        report = reporter.as_bot(
+            f'Match added! match_id: {match_id}. '
+            f'Red: {[player.display_name for player in red_players]}. '
+            f'Blue: {[player.display_name for player in blue_players]}.'
+        )
+
+        for callback in callbacks:
+            await callback(message, report)

--- a/rankone/parser.py
+++ b/rankone/parser.py
@@ -3,43 +3,48 @@ Contains parsing logic to take a message from a PUG game
 and converts it to meangingful data so elo and elo gains can be
 calculated
 '''
+from typing import Tuple, List
+from discord import Message
 from .player import Player, Team
 from . import config
 
 
-def is_match(message_content):
+def is_match(message: Message) -> bool:
     '''
-    Returns True if it is a match
+    Returns true if the message content resembles that of a PUG match
     '''
-    if 'teams have been selected:' in message_content.lower():
+    if 'teams have been selected:' in message.content.lower():
         return True
     else:
         return False
 
 
-def is_monitored_match(mentions):
+def is_monitored_match(message: Message) -> bool:
     '''
     Returns True if the number of mentions matches
     the number of expected players for monitored game modes
     otherwise returns False
     '''
     for game_mode in config.MONITORED_GAME_MODES:
-        if len(mentions) == config.GAME_MODES_TO_PLAYERS[game_mode]:
+        if len(message.mentions) == config.GAME_MODES_TO_PLAYERS[game_mode]:
             return True
     return False
 
 
-def parse_match(message_id, content, mentions):
+def parse_match(message: Message) -> Tuple[int, List[Player], dict]:
     '''
     parses players, teams, and match id from a message
     '''
-    match_id = message_id
-    players = []
-    red_players = []
-    blue_players = []
+    match_id = message.id
+    content = message.content
+    mentions = message.mentions
+
+    players, red_players, blue_players = [], [], []
+
     for mention in mentions:
         players.append(Player(player_id=mention.id, name=mention.name))
 
+    # Assumes a new line separates header from red team and from blue team
     header, red_team_text, blue_team_text = content.split('\n')
     for player in players:
         if str(player.player_id) in red_team_text:

--- a/rankone/player.py
+++ b/rankone/player.py
@@ -1,14 +1,21 @@
-from . import db
+from typing import List
 from trueskill import Rating
+from . import db
 
 
-def avg(items):
+def avg(items: List[int]) -> float:
     return sum(items) / len(items)
 
 
 class Player(object):
     def __init__(
-        self, player_id, name, elo=None, number_of_games=None, rating=None, sigma=None
+        self,
+        player_id: int,
+        name: str,
+        elo: int = None,
+        number_of_games: int = None,
+        rating: Rating = None,
+        sigma: float = None,
     ):
         self.player_id = player_id
         self.name = name
@@ -18,7 +25,7 @@ class Player(object):
         self._rating = rating
 
     @property
-    def elo(self):
+    def elo(self) -> int:
         '''
         Returns the player's current Elo from ranked games
         '''
@@ -28,7 +35,7 @@ class Player(object):
             return db.get_player(self.player_id).elo
 
     @property
-    def number_of_games(self):
+    def number_of_games(self) -> int:
         '''
         Returns the number of ranked games the player has played.
         '''
@@ -38,14 +45,14 @@ class Player(object):
         return f'<{self.name} id: {self.player_id}>'
 
     @property
-    def sigma(self):
+    def sigma(self) -> float:
         if self._sigma:
             return self._sigma
         else:
             return db.get_player(self.player_id).sigma
 
     @property
-    def rating(self):
+    def rating(self) -> Rating:
         if self._rating:
             return self._rating
         else:
@@ -61,20 +68,20 @@ class Team(object):
         self.players = players
 
     @property
-    def combined_elo(self):
+    def combined_elo(self) -> int:
         return sum([player.elo for player in self.players])
 
     @property
-    def average_elo(self):
+    def average_elo(self) -> float:
         return avg([player.elo for player in self.players])
 
     @property
-    def combined_weight(self):
+    def combined_weight(self) -> int:
         return sum([player.number_of_games for player in self.players])
 
     @property
-    def ratings(self):
+    def ratings(self) -> List[Rating]:
         return [player.rating for player in self.players]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ', '.join([str(player) for player in self.players])

--- a/rankone/reporter.py
+++ b/rankone/reporter.py
@@ -1,13 +1,15 @@
+from typing import Callable, Any, List
 import random
 from . import db
+from .player import Player
 from .config import BOT_MESSAGE_PREFIX
 
 
-def as_bot(message):
+def as_bot(message: str) -> str:
     return BOT_MESSAGE_PREFIX + message
 
 
-def bot_message(func):
+def bot_message(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
     def wrapper(*args, **kwargs):
         return as_bot(func(*args, **kwargs))
 
@@ -15,7 +17,7 @@ def bot_message(func):
 
 
 @bot_message
-def get_report(players):
+def get_report(players: List[Player]) -> str:
     report = ', '.join(
         [f'{player.display_name}: {random.randint(900, 1700)}' for player in players]
     )
@@ -23,8 +25,7 @@ def get_report(players):
 
 
 @bot_message
-def get_elo_report(*players, has_updated=False):
-
+def get_elo_report(*players: Player, has_updated: bool = False) -> str:
     report = ', '.join(
         f'{player.display_name} [{player.elo:4.0f}]' for player in players
     )
@@ -35,7 +36,7 @@ def get_elo_report(*players, has_updated=False):
 
 
 @bot_message
-def get_leader_report(players):
+def get_leader_report(players: List[Player]) -> str:
     # assumes players are already sorted in descending
     report = f'Top {len(players)} players: \n'
     for i, player in enumerate(players):

--- a/rankone/utils.py
+++ b/rankone/utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import os
 import subprocess
+from typing import List
 
 from discord import Member
 from discord import utils as discord_utils

--- a/rankone/utils.py
+++ b/rankone/utils.py
@@ -2,23 +2,24 @@ from datetime import datetime
 import os
 import subprocess
 
+from discord import Member
 from discord import utils as discord_utils
 
 from . import db
 
 
 class BackUp(object):
-    def __init__(self, backup_id=None):
+    def __init__(self, backup_id: str = None):
         self.backup_id = backup_id or datetime.now().strftime('%Y%m%d.%H.%M.%S')
         self.db_prefix = 'db.'
         self.backup_path = self.db_prefix + self.backup_id
 
     @property
-    def exists(self):
+    def exists(self) -> bool:
         return os.path.exists(self.backup_path)
 
 
-def backup_db(backup_id=None):
+def backup_db(backup_id: str = None) -> str:
     bk_up = BackUp(backup_id)
     cmd = ['cp', db.sqlite_db['database'], bk_up.backup_path]
     print(cmd)
@@ -26,7 +27,7 @@ def backup_db(backup_id=None):
     return bk_up.backup_id
 
 
-def restore_db(backup_id):
+def restore_db(backup_id: str) -> str:
     bk_up = BackUp(backup_id)
     if bk_up.exists:
         new_bk_id = backup_db()
@@ -41,13 +42,13 @@ def restore_db(backup_id):
     return response
 
 
-def reset_db():
+def reset_db() -> int:
     cmd = ['rm', db.sqlite_db['database']]
     result = subprocess.call(cmd) == 0
     db.session = db.get_session()
     return result
 
 
-def get_display_name(members, player_id):
+def get_display_name(members: List[Member], player_id: int) -> str:
     member = discord_utils.get(members, id=player_id)
     return member.display_name

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='rankone',
-    version='1.1.1',
+    version='1.1.2',
     packages=pkgs,
     description='RankOne is a discord bot that manages a Elo ladder for pickup games.',
     long_description=README,


### PR DESCRIPTION
This is mostly a cosmetic update to the codebase. No major functionality has changed or been added. 

- Previously the `bot` module handled parsing, elo calculation, and db update logic. All this logic is now moved to be handled by MatchManager making it easier to see what the bot intends to do after receiving events.
- Previously type hints were sparse and only added to a few functions. Type hints are now added to all rankone modules. 