### PR TITLE
[1.1.5] Add win probability report to the match added message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Please log all key deployments here. They include all major changes and customiz
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.1.5] - 2020-09-30
+### Added
+- Added match win probability report to the match added message.
+- Added more possible losers to the command `.elo_loser`
+
 ### [1.1.4] - 2020-09-22
 ### Added
 - Added a new command `.elo_losers` to report players with the lowest elos.

--- a/rankone/commands.py
+++ b/rankone/commands.py
@@ -105,7 +105,16 @@ class Commands(commands.Cog):
 
     @commands.command(name='elo_loser')
     async def elo_loser(self, ctx):
-        loser = random.choice(['f00l', 'FlyingLizard', 'LA Clippers'])
+        loser = random.choice(
+            [
+                'f00l',
+                'US stock market',
+                'LA Clippers',
+                'Boston Celtics',
+                'You',
+                'Disneys Mulan',
+            ]
+        )
         await ctx.send(reporter.as_bot(loser))
 
     @commands.command(name='elo_losers')

--- a/rankone/match.py
+++ b/rankone/match.py
@@ -90,10 +90,20 @@ class MatchManager(object):
         red_players = self.update_player_display_names(teams['Red'].players, message)
         blue_players = self.update_player_display_names(teams['Blue'].players, message)
 
+        red_win_probability = get_team1_win_probability(teams['Red'], teams['Blue'])
+        blue_win_probability = 1 - red_win_probability
+        if red_win_probability > blue_win_probability:
+            favored_team = 'Red'
+            percent_win = red_win_probability * 100
+        else:
+            favored_team = 'Blue'
+            percent_win = blue_win_probability * 100
+
         report = reporter.as_bot(
             f'Match added! match_id: {match_id}. '
             f'Red: {[player.display_name for player in red_players]}. '
             f'Blue: {[player.display_name for player in blue_players]}.'
+            f'Probability of {favored_team} winning is {percent_win}%.'
         )
 
         for callback in callbacks:

--- a/rankone/match.py
+++ b/rankone/match.py
@@ -90,7 +90,9 @@ class MatchManager(object):
         red_players = self.update_player_display_names(teams['Red'].players, message)
         blue_players = self.update_player_display_names(teams['Blue'].players, message)
 
-        red_win_probability = get_team1_win_probability(teams['Red'], teams['Blue'])
+        red_win_probability = utils.get_team1_win_probability(
+            teams['Red'], teams['Blue']
+        )
         blue_win_probability = 1 - red_win_probability
         if red_win_probability > blue_win_probability:
             favored_team = 'Red'
@@ -100,10 +102,10 @@ class MatchManager(object):
             percent_win = blue_win_probability * 100
 
         report = reporter.as_bot(
-            f'Match added! match_id: {match_id}. '
-            f'Red: {[player.display_name for player in red_players]}. '
-            f'Blue: {[player.display_name for player in blue_players]}.'
-            f'Probability of {favored_team} winning is {percent_win}%.'
+            f'Match added! match_id: {match_id}.\n'
+            f'Red: {[player.display_name for player in red_players]}.\n'
+            f'Blue: {[player.display_name for player in blue_players]}.\n'
+            f'Probability of {favored_team} winning is {percent_win:4.2f}%.'
         )
 
         for callback in callbacks:

--- a/rankone/utils.py
+++ b/rankone/utils.py
@@ -2,10 +2,13 @@ from datetime import datetime
 import os
 import subprocess
 from typing import List
+import itertools
+import math
 
 from discord import Member
 from discord import utils as discord_utils
 
+from .algorithms import trueskill
 from . import db
 
 
@@ -53,3 +56,15 @@ def reset_db() -> int:
 def get_display_name(members: List[Member], player_id: int) -> str:
     member = discord_utils.get(members, id=player_id)
     return member.display_name
+
+
+def get_team1_win_probability(team1, team2):
+    delta_mu = sum(player.elo for player in team1.players) - sum(
+        player.elo for player in team2.players
+    )
+    sum_sigma = sum(
+        player.sigma ** 2 for player in itertools.chain(team1.players, team2.players)
+    )
+    size = len(team1.players) + len(team2.players)
+    denom = math.sqrt(size * (trueskill.beta * trueskill.beta) + sum_sigma)
+    return trueskill.cdf(delta_mu / denom)

--- a/rankone/utils.py
+++ b/rankone/utils.py
@@ -24,6 +24,9 @@ class BackUp(object):
 
 
 def backup_db(backup_id: str = None) -> str:
+    '''
+    Backup the database.
+    '''
     bk_up = BackUp(backup_id)
     cmd = ['cp', db.sqlite_db['database'], bk_up.backup_path]
     print(cmd)
@@ -32,6 +35,9 @@ def backup_db(backup_id: str = None) -> str:
 
 
 def restore_db(backup_id: str) -> str:
+    '''
+    Restore an existing database.
+    '''
     bk_up = BackUp(backup_id)
     if bk_up.exists:
         new_bk_id = backup_db()
@@ -47,6 +53,9 @@ def restore_db(backup_id: str) -> str:
 
 
 def reset_db() -> int:
+    '''
+    Reset the database by removing the DB file and creating a new session.
+    '''
     cmd = ['rm', db.sqlite_db['database']]
     result = subprocess.call(cmd) == 0
     db.session = db.get_session()
@@ -54,11 +63,18 @@ def reset_db() -> int:
 
 
 def get_display_name(members: List[Member], player_id: int) -> str:
+    '''
+    Get a player's discord display name from discord's API.
+    '''
     member = discord_utils.get(members, id=player_id)
     return member.display_name
 
 
 def get_team1_win_probability(team1, team2):
+    '''
+    Calculate the probability of `team1` winning against `team2.
+    The formula is copied from https://trueskill.org/#win-probability
+    '''
     delta_mu = sum(player.elo for player in team1.players) - sum(
         player.elo for player in team2.players
     )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='rankone',
-    version='1.1.4',
+    version='1.1.5',
     packages=pkgs,
     description='RankOne is a discord bot that manages a Elo ladder for pickup games.',
     long_description=README,


### PR DESCRIPTION
- Calculate the win probability of the two teams in a pickup game and append to the message which team is more likely going to win and by what probability via the formula documented here:
  - https://trueskill.org/#win-probability
- Add more possible losers to the `.elo_loser` command

